### PR TITLE
Fixed imports

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -16,7 +16,8 @@ from boutiques.localExec import ExecutorOutput
 from boutiques.localExec import ExecutorError
 from boutiques.exporter import ExportError
 from boutiques.importer import ImportError
-from boutiques.localExec import loadJson, addDefaultValues
+from boutiques.localExec import addDefaultValues
+from boutiques.util.utils import loadJson
 from boutiques.logger import raise_error
 from tabulate import tabulate
 

--- a/tools/python/boutiques/conftest.py
+++ b/tools/python/boutiques/conftest.py
@@ -1,7 +1,7 @@
 import json
 import tempfile
 import os.path as op
-from boutiques.localExec import loadJson
+from boutiques.util.utils import loadJson
 
 
 def pytest_addoption(parser):

--- a/tools/python/boutiques/dataHandler.py
+++ b/tools/python/boutiques/dataHandler.py
@@ -5,7 +5,7 @@ import time
 import hashlib
 from boutiques import __file__ as bfile
 from boutiques.logger import raise_error, print_info
-from boutiques.localExec import extractFileName, loadJson
+from boutiques.util.utils import extractFileName, loadJson
 from boutiques.zenodoHelper import ZenodoHelper, ZenodoError
 
 

--- a/tools/python/boutiques/exporter.py
+++ b/tools/python/boutiques/exporter.py
@@ -3,7 +3,7 @@
 import json
 import os
 import uuid
-from boutiques.localExec import loadJson
+from boutiques.util.utils import loadJson
 from boutiques.logger import raise_error
 
 

--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser
 from jsonschema import ValidationError
 from boutiques.validator import validate_descriptor
-from boutiques.localExec import loadJson
+from boutiques.util.utils import loadJson
 from boutiques.logger import raise_error
 import boutiques
 import yaml

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -16,6 +16,7 @@ from termcolor import colored
 from boutiques.evaluate import evaluateEngine
 from boutiques.logger import raise_error, print_info
 from boutiques.dataHandler import getDataCacheDir
+from boutiques.util.utils import extractFileName, loadJson
 
 
 class ExecutorOutput():
@@ -1335,32 +1336,6 @@ class LocalExecutor(object):
             print_info("Descriptor from execution saved to cache for future "
                        "publishing as {}".format(filename))
         return filename
-
-
-
-# Helper function that loads the JSON object coming from either a string,
-# a local file or a file pulled from Zenodo
-def loadJson(userInput, verbose=False):
-    # Check for JSON file (local or from Zenodo)
-    json_file = None
-    if os.path.isfile(userInput):
-        json_file = userInput
-    elif userInput.split(".")[0].lower() == "zenodo":
-        from boutiques.puller import Puller
-        puller = Puller([userInput], verbose)
-        json_file = puller.pull()[0]
-    if json_file is not None:
-        with open(json_file, 'r') as f:
-            return json.loads(f.read())
-    # JSON file not found, so try to parse JSON object
-    e = ("Cannot parse input {}: file not found, "
-         "invalid Zenodo ID, or invalid JSON object").format(userInput)
-    if userInput.isdigit():
-        raise_error(ExecutorError, e)
-    try:
-        return json.loads(userInput)
-    except ValueError:
-        raise_error(ExecutorError, e)
 
 
 # Adds default values to input dictionary

--- a/tools/python/boutiques/util/utils.py
+++ b/tools/python/boutiques/util/utils.py
@@ -1,0 +1,43 @@
+import os
+import json
+from boutiques.logger import raise_error
+
+
+# Parses absolute path into filename
+def extractFileName(path):
+    # Helps OS path handle case where "/" is at the end of path
+    if path is None:
+        return None
+    elif path[:-1] == '/':
+        return os.path.basename(path[:-1]) + "/"
+    else:
+        return os.path.basename(path)
+
+
+class LoadError(Exception):
+    pass
+
+
+# Helper function that loads the JSON object coming from either a string,
+# a local file or a file pulled from Zenodo
+def loadJson(userInput, verbose=False):
+    # Check for JSON file (local or from Zenodo)
+    json_file = None
+    if os.path.isfile(userInput):
+        json_file = userInput
+    elif userInput.split(".")[0].lower() == "zenodo":
+        from boutiques.puller import Puller
+        puller = Puller([userInput], verbose)
+        json_file = puller.pull()[0]
+    if json_file is not None:
+        with open(json_file, 'r') as f:
+            return json.loads(f.read())
+    # JSON file not found, so try to parse JSON object
+    e = ("Cannot parse input {}: file not found, "
+         "invalid Zenodo ID, or invalid JSON object").format(userInput)
+    if userInput.isdigit():
+        raise_error(LoadError, e)
+    try:
+        return json.loads(userInput)
+    except ValueError:
+        raise_error(LoadError, e)

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -6,7 +6,7 @@ import json
 from jsonschema import validate, ValidationError
 from argparse import ArgumentParser
 from boutiques import __file__ as bfile
-from boutiques.localExec import loadJson
+from boutiques.util.utils import loadJson
 from boutiques.logger import raise_error, print_info
 
 


### PR DESCRIPTION
This addresses the circular dependency between modules `dataHandler` and `localExec` currently in `friesenA/boutiques:develop`. The fix moves the functions requires by `dataHandler` from `localExec` to `util/utils.py`. In the future we might want to review how modules import each other, and adopt a stricter convention.
@friesenA feel free to ignore the PR and just replicate it in your fork if that's easier.