### PR TITLE
Prevent data capture crash when input file is not found.

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1237,7 +1237,11 @@ class LocalExecutor(object):
                 id = x.get('id')
                 path = public_in_dict.get(id)
                 if path is not None:
-                    public_in_dict[id] = self._buildPublicFile(path)
+                    if isinstance(path, list):
+                        public_in_dict[id] = [ self._buildPublicFile(p)
+                                              for p in path ]
+                    else:
+                        public_in_dict[id] = self._buildPublicFile(path)
 
         return public_in_dict
 

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1265,6 +1265,9 @@ class LocalExecutor(object):
     # Private method to recursively explore directory and hash all files
     def _buildPublicFile(self, path):
         filename = extractFileName(path)
+        # If path is not found, report it
+        if not os.path.exists(path):
+            return {'file-name': filename, 'not_found': True}
         # Directories are expanded recursively
         if os.path.isdir(path):
             contents = os.listdir(path)

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -172,45 +172,42 @@ class Publisher():
         keywords = data['metadata']['keywords']
         if self.descriptor.get('tags'):
             for key, value in self.descriptor.get('tags').items():
-                # Check if value is a string or a list of strings
-                if self.is_str(value):
+                # Tag is of form 'tag-name': true, it is a single-string
+                if isinstance(value, bool):
+                    keywords.append(key)
+                # Tag is of form 'tag-name':'tag-value', it is a key-value pair
+                elif self.is_str(value):
                     keywords.append(key + ":" + value)
-                else:
+                # Tag is of form 'tag-name': ['value1', 'value2'], it is a
+                # list of key-value pairs
+                elif isinstance(value, list):
                     keywords += [key + ":" + item for item in value]
+                else:
+                    # This should never happen as the descriptor is assumed
+                    # valid at this point
+                    raise_error(ValidationError,
+                                'Invalid tag format: {0}:{1}'.format(key, value))
         if self.descriptor.get('container-image'):
             keywords.append(self.descriptor['container-image']['type'])
         if self.descriptor.get('tests'):
             keywords.append('tested')
         if self.url is not None:
-            if data['metadata'].get('related_identifiers') is None:
-                data['metadata']['related_identifiers'] = []
-            data['metadata']['related_identifiers'].append({
-                'identifier': self.url,
-                'relation': 'hasPart'
-            })
+            self.addHasPart(data, self.url)
         if self.online_platforms is not None:
-            if data['metadata'].get('related_identifiers') is None:
-                data['metadata']['related_identifiers'] = []
             for p in self.online_platforms:
-                data['metadata']['related_identifiers'].append({
-                    'identifier': p,
-                    'relation': 'hasPart'
-                })
+                self.addHasPart(data, p)
         if self.tool_doi is not None:
-            if data['metadata'].get('related_identifiers') is None:
-                data['metadata']['related_identifiers'] = []
-            data['metadata']['related_identifiers'].append({
-                'identifier': self.tool_doi,
-                'relation': 'hasPart'
-            })
+            self.addHasPart(data, self.tool_doi)
         if self.descriptor_url is not None:
-            if data['metadata'].get('related_identifiers') is None:
-                data['metadata']['related_identifiers'] = []
-            data['metadata']['related_identifiers'].append({
-                'identifier': self.descriptor_url,
-                'relation': 'hasPart'
-            })
+            self.addHasPart(data, self.descriptor_url)
+        if self.deprecated_by_doi:  # might be None or False
+            # Add deprecated keyword
+            keywords.append('deprecated')
+            # Add link to new doi if available
+            if self.is_str(self.deprecated_by_doi):
+                self.addHasPart(data, self.deprecated_by_doi)
         return data
+
 
     # checks if value is a string
     # try/except is needed for Python2/3 compatibility


### PR DESCRIPTION
Small fix to avoid crashing when input file is not found. This happens in `2636975` because input `outfile` should be `String` instead of `File`. 